### PR TITLE
Add custom texts support

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,18 @@ Offset between the component and the tooltip.
 **tooltipOptions.tooltipComponent** {ReactNode} > `null` <br>
 Component to display instead of the default tooltip. _(see [Custom Tooltip](#custom-tooltip))_
 
+**tooltipOptions.nextButtonText** {string or function(current: number, steps: number): string} > `` (current, steps) => `Next (${current}/${steps})` ``<br>
+Text for "Next" button. You may either provide the string directly or provide a function that receives two numbers (the current step as first argument and the total number of steps) and returns a string.
+
+**tooltipOptions.prevButtonText** {string} > `Previous`<br>
+Text for "Previous" button.
+
+**tooltipOptions.skipButtonText** {string} > `Skip`<br>
+Text for "Skip" button.
+
+**tooltipOptions.finishButtonText** {string} > `Finish`<br>
+Text for "Finish" button.
+
 ## Custom Tooltip
 
 Your custom component will receive props from the `Walkthrough` :

--- a/src/WalkthroughTooltip.js
+++ b/src/WalkthroughTooltip.js
@@ -37,7 +37,11 @@ const WalkthroughTooltip = React.memo(props => {
       borderRadius,
       backgroundColor,
       fontSize,
-      content
+      content,
+      skipButtonText,
+      prevButtonText,
+      nextButtonText,
+      finishButtonText
     },
     tooltipcntx: { onPrev, onNext, onSkip, current, steps },
     duration,
@@ -97,7 +101,7 @@ const WalkthroughTooltip = React.memo(props => {
       >
         <CustomButton
           callback={onSkip}
-          text="Skip"
+          text={skipButtonText}
           buttonStyle={buttons.buttonSkip}
           textStyle={{ fontSize: 12, color: '#7F8C8D' }}
         />
@@ -109,7 +113,7 @@ const WalkthroughTooltip = React.memo(props => {
           {hasPrevious ? (
             <CustomButton
               callback={onPrev}
-              text="Previous"
+              text={prevButtonText}
               buttonStyle={buttons.buttonPrev}
               textStyle={{ fontSize: 12, color: '#27AE60' }}
             />
@@ -119,7 +123,7 @@ const WalkthroughTooltip = React.memo(props => {
             style={{
               justifyContent: 'center'
             }}
-            text={current < steps ? `Next (${current}/${steps})` : 'Finish'}
+            text={current < steps ? (typeof nextButtonText === 'function' ? nextButtonText(current, steps) : nextButtonText) : finishButtonText}
             buttonStyle={buttons.buttonNext}
             textStyle={{ fontSize: 12, fontWeight: 'bold', color: 'white' }}
           />

--- a/src/Walktrhough.js
+++ b/src/Walktrhough.js
@@ -39,7 +39,11 @@ const defOpts = {
     placement: { value: null, valid: v => tooltipPlacement.includes(v) },
     offsetCenter: { value: 0, valid: v => typeof v === 'number' },
     offset: { value: 20, valid: v => typeof v === 'number' },
-    tooltipComponent: { value: null }
+    tooltipComponent: { value: null },
+    skipButtonText: { value: "Skip", valid: v => typeof v === 'string' },
+    prevButtonText: { value: "Previous", valid: v => typeof v === 'string' },
+    nextButtonText: { value: (current, steps) => `Next (${current}/${steps})`, valid: ['string', 'function'].includes(typeof v) },
+    finishButtonText: { value: "Finish", valid: v => typeof v === 'string' }
   }
 };
 

--- a/src/Walktrhough.js
+++ b/src/Walktrhough.js
@@ -42,7 +42,7 @@ const defOpts = {
     tooltipComponent: { value: null },
     skipButtonText: { value: "Skip", valid: v => typeof v === 'string' },
     prevButtonText: { value: "Previous", valid: v => typeof v === 'string' },
-    nextButtonText: { value: (current, steps) => `Next (${current}/${steps})`, valid: ['string', 'function'].includes(typeof v) },
+    nextButtonText: { value: (current, steps) => `Next (${current}/${steps})`, valid: v => ['string', 'function'].includes(typeof v) },
     finishButtonText: { value: "Finish", valid: v => typeof v === 'string' }
   }
 };


### PR DESCRIPTION
This PR adds support to customising the tooltip buttons text (Previous, Next, Finish, Skip) without having to use custom tooltips.

Specially for the Next, it's possible to provide a string directly or a function that handles the current/steps and returns a string (more details were put on the readme).

Example usage (a valid usecase, as seen below, is l10n-ing):

```javascript
<Walkthrough
            tooltipOptions={{
              prevButtonText: "Voltar",
              nextButtonText: (current, steps) => `Próx. (${current}/${steps})`,
              skipButtonText: "Pular",
              finishButtonText: "OK"
            }}
/>
```